### PR TITLE
Hardware pixel format conversions when returning data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ There are just 4 functions and 3 user-visible data types:
 - `hvd_close`
 
 ```C
-	struct hvd_config hardware_config = {"vaapi", "h264", "/dev/dri/renderD128"};
+	struct hvd_config hardware_config = {"vaapi", "h264", "/dev/dri/renderD128", "rgb0"};
 	struct hvd *hardware_decoder = hvd_init(&hardware_config);
 	struct hvd_packet packet= {0}; //here we will be passing encoded data
 
@@ -202,4 +202,3 @@ Like in LGPL, if you modify this library, you have to make your changes availabl
 Making a github fork of the library with your changes satisfies those requirements perfectly.
 
 You are linking to FFmpeg libraries. Consider also `avcodec` and `avutil` and the codec licensing.
-

--- a/examples/hvd_decoding_example.c
+++ b/examples/hvd_decoding_example.c
@@ -21,7 +21,7 @@ int hint_on_init_failure_and_return_1(const struct hvd_config *hardware_config);
 
 int main(int argc, char **argv)
 {	
-	struct hvd_config hardware_config;
+	struct hvd_config hardware_config = {0};
 	struct hvd* hardware_decoder;
 
 	if(process_user_input(argc, argv, &hardware_config) != 0)

--- a/hvd.c
+++ b/hvd.c
@@ -34,6 +34,7 @@ struct hvd
 static struct hvd *hvd_close_and_return_null(struct hvd *h);
 static enum AVPixelFormat hvd_find_pixel_fmt_by_hw_type(const enum AVHWDeviceType type);
 static enum AVPixelFormat hvd_get_hw_pix_format(AVCodecContext *ctx, const enum AVPixelFormat *pix_fmts);
+static void hvd_dump_sw_pix_formats(struct hvd *h);
 
 //NULL on error
 struct hvd *hvd_init(const struct hvd_config *config)
@@ -265,10 +266,33 @@ AVFrame *hvd_receive_frame(struct hvd *h, int *error)
 
 	if ( (ret = av_hwframe_transfer_data(h->sw_frame, h->hw_frame, 0) ) < 0)
 	{
-		fprintf(stderr, "hvd: unable to transfer data to system memory\n");
+		fprintf(stderr, "hvd: unable to transfer data to system memory - \"%s\"\n", av_err2str(ret));
+		hvd_dump_sw_pix_formats(h);
 		return NULL;
 	}
 
 	*error=HVD_OK;
 	return h->sw_frame;
+}
+
+static void hvd_dump_sw_pix_formats(struct hvd *h)
+{
+	enum AVPixelFormat *formats, *iterator;
+
+	if(av_hwframe_transfer_get_formats(h->hw_frame->hw_frames_ctx, AV_HWFRAME_TRANSFER_DIRECTION_FROM, &formats, 0) < 0)
+	{
+		fprintf(stderr, "hvd: failed to get transfer formats\n");
+		return;
+	}
+	iterator=formats;
+
+	fprintf(stderr, "hvd: make sure you are using supported software pixel format:\n");
+
+	while(*iterator != AV_PIX_FMT_NONE)
+	{
+		fprintf(stderr, "%d : %s\n", *iterator, av_get_pix_fmt_name (*iterator));
+		++iterator;
+	}
+
+	av_free(formats);
 }

--- a/hvd.h
+++ b/hvd.h
@@ -64,6 +64,22 @@ struct hvd;
  * - vp9
  * - ...
  *
+ * The pixel_format is format you want to receive data in.
+ * Only hardware conversions are supported. If you select
+ * something unsupported by hardware, the library will dump for you
+ * list of supported pixel formats to standard error. From my experience
+ * even those reported are not supported in all scenarios.
+ *
+ * Typical examples:
+ * - nv12
+ * - yuv420p (this is generally safe choice)
+ * - rgb0
+ * - bgr0
+ * - ...
+ *
+ * For pixel format explanation see:
+ * <a href="https://ffmpeg.org/doxygen/3.4/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5">FFmpeg pixel formats</a>
+ *
  * @see hvd_init
  */
 struct hvd_config
@@ -71,7 +87,7 @@ struct hvd_config
 	const char *hardware; //!< hardware type for decoding, e.g. "vaapi"
 	const char *codec; //!< codec name, e.g. "h264", "vp8"
 	const char *device; //!< NULL or device, e.g. "/dev/dri/renderD128"
-	const char *pixel_format; //!< NULL for default or format, e.g. "RGB0", "BGR0", "NV12", "YUV420P"
+	const char *pixel_format; //!< NULL for default or format, e.g. "rgb0", "bgr0", "nv12", "yuv420p"
 };
 
 /**
@@ -136,10 +152,10 @@ void hvd_close(struct hvd *h);
  * If you have simple loop like:
  * - send encoded data with hve_send_packet
  * - receive decoded data with hve_receive_frame
- * 
+ *
  * HVD_AGAIN return value will never happen.
  * If you are sending lots of data and not reading you may get HVD_AGAIN when buffers are full.
- * 
+ *
  * When you are done with decoding call with:
  * - NULL packet argument
  * - or packet with NULL data and 0 size
@@ -155,15 +171,15 @@ void hvd_close(struct hvd *h);
  * @return
  * - HVD_OK on success
  * - HVD_ERROR on error
- * - HVD_AGAIN input was rejected, read data with hvd_receive_packet before next try 
+ * - HVD_AGAIN input was rejected, read data with hvd_receive_packet before next try
  *
  * @see hvd_packet, hvd_receive_frame
- * 
+ *
  * Example flushing:
  * @code
  *  //flush
  *  hvd_send_packet(hardware_decoder, NULL);
- *  
+ *
  *  //retrieve last frames from decoder as usual
  *	while( (frame=hvd_receive_frame(hardware_decoder, &failed)) )
  *	{
@@ -196,13 +212,13 @@ int hvd_send_packet(struct hvd *h, struct hvd_packet *packet);
  * - NULL when no more data is pending, query error argument to check result (HVD_OK on success)
  *
  * @see hvd_send_packet
- * 
+ *
  * Example (in decoding loop):
  * @code
  * //send data for hardware decoding
  * if(hvd_send_packet(h, packet) != HVD_OK)
  *   break; //break on error
- * 
+ *
  * //get the decoded data
  * while( (frame = hvd_receive_frame(av, &error) ) )
  * {

--- a/hvd.h
+++ b/hvd.h
@@ -71,6 +71,7 @@ struct hvd_config
 	const char *hardware; //!< hardware type for decoding, e.g. "vaapi"
 	const char *codec; //!< codec name, e.g. "h264", "vp8"
 	const char *device; //!< NULL or device, e.g. "/dev/dri/renderD128"
+	const char *pixel_format; //!< NULL for default or format, e.g. "RGB0", "BGR0", "NV12", "YUV420P"
 };
 
 /**


### PR DESCRIPTION
Adds possibility to specify the pixel format that the user wants data in:
- only hardware conversions are supported
- if user selects something unsupported a list of formats supported by hardware is dumped to stderr (during decoding)