### PR TITLE
Nvidia NVDEC/CUVID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This library wraps hardware video decoding in a simple interface.
 There are no performance loses (at the cost of library flexibility).
 
-Currently it supports VAAPI, VDPAU (tested) and a few other hardware decoders (not tested).
+Currently it supports VAAPI, VDPAU, NVDEC/CUVID (tested) and a few other hardware decoders (not tested).\
 Various codecs are supported (e.g. H.264, HEVC, VP8, VP9)
 
 See library [documentation](https://bmegli.github.io/hardware-video-decoder/group__interface.html).
@@ -30,7 +30,8 @@ Cross-platform but tested only on Linux (Ubuntu 18.04).
 Tested with:
 - Intel VAAPI compatible hardware decoders ([Quick Sync Video](https://ark.intel.com/Search/FeatureFilter?productType=processors&QuickSyncVideo=true))
 - AMD/ATI VAAPI compatible hardware decoders
-- VDPAU compatible hardware decoders (e.g. Nvidia GPU) 
+- VDPAU compatible hardware decoders (e.g. Nvidia GPU)
+- Nvidia NVDEC compatible hardware decoders (e.g. Nvidia GPU)
 
 Also implemented (but not tested):
 - DirectX 9 Video Acceleration (dxva2)
@@ -42,11 +43,13 @@ Also implemented (but not tested):
 Library depends on:
 - FFmpeg `avcodec` and `avutil` (at least 3.4 version)
 
-Works with system FFmpeg on Ubuntu 18.04 and doesn't on 16.04 (outdated FFmpeg and VAAPI ecosystem).
+Works with:
+- system FFmpeg on Ubuntu 18.04
+- system FFmpeg on Ubuntu 20.04
 
 ## Building Instructions
 
-Tested on Ubuntu 18.04.
+Tested on Ubuntu 18.04 and 20.04
 
 ``` bash
 # update package repositories

--- a/examples/hvd_decoding_example.c
+++ b/examples/hvd_decoding_example.c
@@ -1,7 +1,7 @@
 /*
  * HVD Hardware Video Decoder example (template for simple program)
  *
- * Copyright 2019 (C) Bartosz Meglicki <meglickib@gmail.com>
+ * Copyright 2019-2023 (C) Bartosz Meglicki <meglickib@gmail.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -110,6 +110,8 @@ int process_user_input(int argc, char **argv, struct hvd_config *config)
 		fprintf(stderr, "%s dxva2 h264 \n", argv[0]);
 		fprintf(stderr, "%s d3d11va h264 \n", argv[0]);
 		fprintf(stderr, "%s videotoolbox h264 \n", argv[0]);
+		fprintf(stderr, "%s cuda h264_cuvid \n", argv[0]);
+		fprintf(stderr, "%s cuda hevc_cuvid \n", argv[0]);
 		fprintf(stderr, "%s vaapi hevc /dev/dri/renderD128 848 480 1 \n", argv[0]);
 		return 1;
 	}

--- a/hvd.c
+++ b/hvd.c
@@ -1,7 +1,7 @@
 /*
  * HVD Hardware Video Decoder C library imlementation
  *
- * Copyright 2019-2020 (C) Bartosz Meglicki <meglickib@gmail.com>
+ * Copyright 2019-2023 (C) Bartosz Meglicki <meglickib@gmail.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/hvd.c
+++ b/hvd.c
@@ -129,6 +129,9 @@ static enum AVPixelFormat hvd_find_pixel_fmt_by_hw_type(const enum AVHWDeviceTyp
 	case AV_HWDEVICE_TYPE_VIDEOTOOLBOX:
 		fmt = AV_PIX_FMT_VIDEOTOOLBOX;
 		break;
+	case AV_HWDEVICE_TYPE_CUDA:
+		fmt = AV_PIX_FMT_CUDA;
+		break;
 	default:
 		fmt = AV_PIX_FMT_NONE;
 		break;

--- a/hvd.h
+++ b/hvd.h
@@ -1,7 +1,7 @@
 /*
  * HVD Hardware Video Decoder C library header
  *
- * Copyright 2019-2020 (C) Bartosz Meglicki <meglickib@gmail.com>
+ * Copyright 2019-2023 (C) Bartosz Meglicki <meglickib@gmail.com>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -52,6 +52,7 @@ struct hvd;
  * - dxva2
  * - d3d11va
  * - videotoolbox
+ * - cuda (for Nvidia NVDEC/CUVID)
  *
  * The device can be:
  * - NULL (select automatically)
@@ -63,12 +64,22 @@ struct hvd;
  * - vp8
  * - vp9
  * - ...
+ * - h264_cuvid (Nvidia NVDEC/CUVID decoder)
+ * - hevc_cuvid (Nvidia NVDEC/CUVID decoder)
+ * - ...
+ *
+ * When using Nvidia (hardware == "cuda") you need to specify codec as "[codec]_cuvid" (e.g. "h264_cuvid")
  *
  * The pixel_format is format you want to receive data in.
  * Only hardware conversions are supported. If you select
  * something unsupported by hardware, the library will dump for you
  * list of supported pixel formats to standard error. From my experience
  * even those reported are not supported in all scenarios.
+ *
+ * Nvidia cuvid (h264_cuvid, hevc_cuvid, ...) has a quirk.
+ * If you select pixel format unsupported by hardware it will silently
+ * return data in nv12 (or p010le, p016le, ... depending on bit depth)
+ * The frame format may still be set to what you requested.
  *
  * Typical examples:
  * - nv12


### PR DESCRIPTION
Add Nvidia path and examples

Quirks:
- data may be silently returned in nv12/p010le/p016le/... even if requested in other format
  - silently means no error reported and frame would still report requested format
- codec may have to be specified as `[codec]_cuvid` (e.g. `h264_cuvid`)

See #17 